### PR TITLE
Fix bump() array indexing bug in zsh

### DIFF
--- a/funcs.zsh
+++ b/funcs.zsh
@@ -99,6 +99,9 @@ tag() {
 	elif [[ -f "Cargo.toml" ]]; then
 		version_file="Cargo.toml"
 		file_type="cargo_toml"
+	elif [[ -f ".version" ]]; then
+		version_file=".version"
+		file_type="dot_version"
 	else
 		manifests=(custom_components/*/manifest.json(N))
 	fi
@@ -110,7 +113,7 @@ tag() {
 		echo "multiple manifest.json files found under custom_components" >&2
 		return 1
 	elif [[ -z "${file_type:-}" ]]; then
-		echo "missing package.json, setup.cfg, pyproject.toml, Cargo.toml, or custom_components/*/manifest.json" >&2
+		echo "missing package.json, setup.cfg, pyproject.toml, Cargo.toml, .version, or custom_components/*/manifest.json" >&2
 		return 1
 	fi
 
@@ -121,6 +124,9 @@ tag() {
 		version="$(perl -ne 'if (/^[ \t]*version[ \t]*=[ \t]*([0-9]+\.[0-9]+\.[0-9]+)[ \t]*$/) { print "$1\n"; exit }' "$version_file")"
 	elif [[ "$file_type" == "cargo_toml" || "$file_type" == "pyproject_toml" ]]; then
 		version="$(perl -ne 'if (/^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/) { print "$1\n"; exit }' "$version_file")"
+	elif [[ "$file_type" == "dot_version" ]]; then
+		version="$(<"$version_file")"
+		version="${version%%$'\n'*}"
 	else
 		version="$(jq -r '.version' "$version_file")" || return 1
 	fi
@@ -159,6 +165,8 @@ tag() {
 		perl -0pi -e "s/^[ \t]*version[ \t]*=[ \t]*[0-9]+\.[0-9]+\.[0-9]+[ \t]*\$/version = $new_version/m" "$version_file" || return 1
 	elif [[ "$file_type" == "cargo_toml" || "$file_type" == "pyproject_toml" ]]; then
 		perl -0pi -e "s/^(version\\s*=\\s*)\"[0-9]+\\.[0-9]+\\.[0-9]+\"/\${1}\"$new_version\"/m" "$version_file" || return 1
+	elif [[ "$file_type" == "dot_version" ]]; then
+		printf '%s\n' "$new_version" >"$version_file" || return 1
 	else
 		jq --arg version "$new_version" '.version = $version' "$version_file" >"$version_file.tmp" || return 1
 		mv "$version_file.tmp" "$version_file" || return 1

--- a/funcs.zsh
+++ b/funcs.zsh
@@ -275,7 +275,7 @@ bump() {
 	local i escaped_lib f
 	local -a matched_files
 
-	for i in "${(@k)libs}"; do
+	for i in {1..${#libs}}; do
 		lib="${libs[$i]}"
 		ver="${vers[$i]}"
 		escaped_lib="$(printf '%s' "$lib" | perl -pe 's/([^A-Za-z0-9_])/\\$1/g')"
@@ -356,14 +356,14 @@ bump() {
 		pr_body="Automated dependency bump for \`${libs[1]}\` to \`${vers[1]}\`."
 	else
 		local -a bump_list
-		for i in "${(@k)libs}"; do
+		for i in {1..${#libs}}; do
 			bump_list+=("${libs[$i]} to ${vers[$i]}")
 		done
 		commit_title="Bump ${(j:, :)bump_list}"
 		pr_title="$commit_title"
 		local bullet
 		pr_body=""
-		for i in "${(@k)libs}"; do
+		for i in {1..${#libs}}; do
 			pr_body+="- \`${libs[$i]}\` -> \`${vers[$i]}\`"$'\n'
 		done
 	fi
@@ -398,7 +398,7 @@ bump() {
 		echo "gh not found; skipping PR creation and auto-merge"
 	fi
 
-	for i in "${(@k)libs}"; do
+	for i in {1..${#libs}}; do
 		echo "done: ${libs[$i]} -> ${vers[$i]}"
 	done
 }

--- a/funcs.zsh
+++ b/funcs.zsh
@@ -125,8 +125,7 @@ tag() {
 	elif [[ "$file_type" == "cargo_toml" || "$file_type" == "pyproject_toml" ]]; then
 		version="$(perl -ne 'if (/^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/) { print "$1\n"; exit }' "$version_file")"
 	elif [[ "$file_type" == "dot_version" ]]; then
-		version="$(<"$version_file")"
-		version="${version%%$'\n'*}"
+		version="$(head -1 "$version_file")"
 	else
 		version="$(jq -r '.version' "$version_file")" || return 1
 	fi


### PR DESCRIPTION
#### Problem
\`bump()\` used \`\${(@k)libs}\` to iterate array indices, but in zsh this expands to array values for normal arrays (not indices like bash). This silently emptied \`lib\`/\`ver\` lookups and broke the function for any usage.

#### Solution
Replace with a numeric range \`{1..\${#libs}}\` for index iteration. Verified by running \`bump manager-for-ynab:latest\` against a real repo — correctly updated files, committed, pushed, and opened an automerge PR.