### PR TITLE
Fix tag() picking version file without a version field

### DIFF
--- a/funcs.zsh
+++ b/funcs.zsh
@@ -90,13 +90,13 @@ tag() {
 	if [[ -f "package.json" ]]; then
 		version_file="package.json"
 		file_type="package_json"
-	elif [[ -f "setup.cfg" ]]; then
+	elif [[ -f "setup.cfg" ]] && grep -qE '^[ \t]*version[ \t]*=[ \t]*[0-9]+\.[0-9]+\.[0-9]+[ \t]*$' setup.cfg; then
 		version_file="setup.cfg"
 		file_type="setup_cfg"
-	elif [[ -f "pyproject.toml" ]]; then
+	elif [[ -f "pyproject.toml" ]] && grep -qE '^version\s*=\s*"[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml; then
 		version_file="pyproject.toml"
 		file_type="pyproject_toml"
-	elif [[ -f "Cargo.toml" ]]; then
+	elif [[ -f "Cargo.toml" ]] && grep -qE '^version\s*=\s*"[0-9]+\.[0-9]+\.[0-9]+"' Cargo.toml; then
 		version_file="Cargo.toml"
 		file_type="cargo_toml"
 	elif [[ -f ".version" ]]; then


### PR DESCRIPTION
#### Problem
tag() picked package.json/setup.cfg/pyproject.toml/Cargo.toml purely by file existence, so a repo with a tooling-only pyproject.toml (no version field) failed with "could not parse version" instead of falling through to a manifest.json. Verified against ha-manager-for-ynab, which has both files.

#### Solution
Require a matching version line in each candidate file before selecting it as the file_type.