### PR TITLE
Pull latest main in bump() before editing files

### DIFF
--- a/funcs.zsh
+++ b/funcs.zsh
@@ -271,6 +271,9 @@ bump() {
 		return 1
 	}
 
+	git checkout main || return 1
+	git pull --ff-only || return 1
+
 	local -a all_changed_files
 	local i escaped_lib f
 	local -a matched_files


### PR DESCRIPTION
#### Problem
bump() edits dependency files on whatever branch is currently checked out, without syncing main first, so bumps can be based on stale main.

#### Solution
Checkout main and git pull --ff-only before editing files, matching tag()'s existing behavior.